### PR TITLE
upgrade to mjml4

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,9 +5,9 @@ import { components } from 'mjml-core'
 import MJMLParser from 'mjml-parser-xml'
 import MJMLValidator from 'mjml-validator'
 
-import find from 'lodash/find'
-
-const getMJBody = (root) => find(root.children, ['tagName', 'mj-body'])
+function wrapIntoMJMLTags(content) {
+  return `<mjml><mj-body>${content}</mj-body></mjml>`
+}
 
 export default {
   activate() {
@@ -29,7 +29,11 @@ export default {
         return new Promise((resolve, reject) => {
           let MJMLDocument
           const filePath = TextEditor.getPath();
-          const fileText = TextEditor.getText()
+          let fileText = TextEditor.getText()
+
+          if (fileText.trim().indexOf('<mjml') !== 0) {
+            fileText = wrapIntoMJMLTags(fileText)
+          }
 
           try {
             MJMLDocument = MJMLParser(fileText, {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use babel';
 
 import mjml from 'mjml'
-import { components } from 'mjml-core'
+import { components, initializeType } from 'mjml-core'
 import MJMLParser from 'mjml-parser-xml'
 import MJMLValidator from 'mjml-validator'
 
@@ -44,7 +44,7 @@ export default {
             reject(e)
           }
 
-          const errors = MJMLValidator(MJMLDocument, { components })
+          const errors = MJMLValidator(MJMLDocument, { components, initializeType })
 
           const formattedError = errors.map(e => {
             const line = e.line - 1
@@ -57,6 +57,7 @@ export default {
               text: e.message
             }
           })
+
           resolve(formattedError)
         })
       }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,10 @@
 'use babel';
 
-import { documentParser, MJMLValidator } from 'mjml'
+import mjml from 'mjml'
+import { components } from 'mjml-core'
+import MJMLParser from 'mjml-parser-xml'
+import MJMLValidator from 'mjml-validator'
+
 import find from 'lodash/find'
 
 const getMJBody = (root) => find(root.children, ['tagName', 'mj-body'])
@@ -28,19 +32,17 @@ export default {
           const fileText = TextEditor.getText()
 
           try {
-            MJMLDocument = documentParser(fileText)
+            MJMLDocument = MJMLParser(fileText, {
+              components,
+              filePath: '.',
+            })
           } catch (e) {
             reject(e)
           }
 
-          const body = getMJBody(MJMLDocument)
+          const errors = MJMLValidator(MJMLDocument, { components })
 
-          if (!body || !body.children || body.children.length == 0) {
-            reject()
-          }
-
-          const report = MJMLValidator(body.children[0])
-          const formattedError = report.map(e => {
+          const formattedError = errors.map(e => {
             const line = e.line - 1
             const currentLine = TextEditor.getBuffer().lineForRow(e.line - 1)
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "atom-linter": "^8.0.0",
     "atom-package-deps": "^4.0.1",
     "lodash": "^4.17.4",
-    "mjml": "^4.0.0"
+    "mjml": "^4.2.0"
   },
   "devDependencies": {
     "eslint": "^3.7.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "atom-linter": "^8.0.0",
     "atom-package-deps": "^4.0.1",
     "lodash": "^4.17.4",
-    "mjml": "^3.3.3"
+    "mjml": "^4.0.0"
   },
   "devDependencies": {
     "eslint": "^3.7.1",


### PR DESCRIPTION
`import mjml from 'mjml'` is necessary even if we don't use it, otherwise components are not registered and `components` from mjml-core is empty